### PR TITLE
floatの背景色修正

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -12,6 +12,7 @@ h1, h2, h3, h4, h5 {
     width: 1000px;
     margin: 0 auto 0 auto;
     background-color: yellow;
+    overflow: hidden;
 }
 
 .logo {


### PR DESCRIPTION
.containerのstyleにoverflow: hidden;を追加

## 原因
![image](https://user-images.githubusercontent.com/363006/81824593-9e201580-9570-11ea-873c-bb0cda184eb0.png)

## 参考サイト
[float：親ボックスの背景色が表示されない件について](https://pata2.jp/127/stylesheets/css_others/float_container.html)

## 動作確認
![image](https://user-images.githubusercontent.com/363006/81824548-8ea0cc80-9570-11ea-8c59-e396970d4c7e.png)


